### PR TITLE
"Iters" method for mpCtrl should be able to handle NULL.

### DIFF
--- a/R/mpCtrl-class.R
+++ b/R/mpCtrl-class.R
@@ -124,10 +124,12 @@ setMethod("show", signature(object = "mpCtrl"),
 setMethod("iters", signature(object = "mpCtrl"), function(object, iter){
 
 	ctrl <- lapply(object, function(x) {
-		lst0 <- lapply(x@args, function(y){
-			if(is(y, "FLQuant")) FLCore::iter(y,iter) else y	
-		})
-		args(x) <- lst0
+		if(!is.null(x)) {
+			lst0 <- lapply(x@args, function(y){
+				if(is(y, "FLQuant")) FLCore::iter(y,iter) else y	
+			})
+			args(x) <- lst0
+		}
 		x
 	})
 	mpCtrl(ctrl)


### PR DESCRIPTION
Some objects in mpCtrl are allowed to be NULL. Therefore, ensure "iters" method can handle NULL as well.