### PR TITLE
adapt "it" when running parallelized

### DIFF
--- a/R/mp.R
+++ b/R/mp.R
@@ -100,6 +100,8 @@ mp <- function(om, oem=NULL, iem=NULL, ctrl, args, scenario="test", tracking="mi
 					ctrl= iters(ctrl, i),
 					args=args,
 					verbose=verbose)
+				# reduce iter to i
+				call0$args$it <- length(i)
 				out <- do.call(goFish, call0)
 				# RETURN
 				list(stk.om=out$stk.om, tracking=out$tracking, oem=out$oem)


### PR DESCRIPTION
`it` in `args` should be adapted when running parallelized.
This is later used in `goFish()`, e.g. here: https://github.com/flr/mse/blob/43b1851bd353518da715c33a5f0961c22a472ea1/R/mp.R#L333