### PR TITLE
fix output of fwdControl()$value for latest version of FLasher

### DIFF
--- a/R/mp.R
+++ b/R/mp.R
@@ -292,7 +292,7 @@ goFish <- function(stk.om, sr.om, sr.om.res, sr.om.res.mult, fb,
 		} else {
 			ctrl <- getCtrl(yearMeans(fbar(stk0)[,sqy]), "f", ay+args$management_lag, it)
 		}
-		tracking["metric.hcr", ac(ay)] <- ctrl$value[1,]
+		tracking["metric.hcr", ac(ay)] <- ctrl$value
 		
 		#----------------------------------------------------------
 		# Implementation system
@@ -310,7 +310,7 @@ goFish <- function(stk.om, sr.om, sr.om.res, sr.om.res.mult, fb,
 			ctrl <- out$ctrl
 			tracking <- out$tracking
 		}		
-		tracking["metric.is", ac(ay)] <- ctrl$value[1,]
+		tracking["metric.is", ac(ay)] <- ctrl$value
 
 		#----------------------------------------------------------
 		# Technical measures
@@ -343,7 +343,7 @@ goFish <- function(stk.om, sr.om, sr.om.res, sr.om.res.mult, fb,
 			ctrl <- out$ctrl
 			tracking <- out$tracking
 		}
-		tracking["metric.iem",ac(ay)] <- ctrl$value[1,]
+		tracking["metric.iem",ac(ay)] <- ctrl$value
 
 		#==========================================================
 		# OM
@@ -362,7 +362,7 @@ goFish <- function(stk.om, sr.om, sr.om.res, sr.om.res.mult, fb,
 			tracking <- out$tracking
 		}
 	  # TODO value()
-		tracking["metric.fb",ac(ay)] <- ctrl$value[1,]
+		tracking["metric.fb",ac(ay)] <- ctrl$value
 
 		#----------------------------------------------------------
 		# stock dynamics and OM projections


### PR DESCRIPTION
In the latest version of FLasher, the output of fwdControl()$value is always a vector:
https://github.com/flr/FLasher/blob/8e87f10f6c78cfb5c0c6bd925b9bc31a3b429a88/R/methods.R#L156
`      return(c(res[!is.na(c(res))]))`

Consequently, `ctrl$value[1,]` leads to an error when running `mp()`.