### PR TITLE
fix iter (iters) for FLoem

### DIFF
--- a/R/FLoem-class.R
+++ b/R/FLoem-class.R
@@ -125,6 +125,11 @@ setMethod("deviances", "FLoem",
 
     return(res)
   })
+#' @rdname FLoem-class
+setReplaceMethod("deviances", signature("FLoem", "list"), function(object, value){
+  object@deviances <- value
+  object
+})
 
 #' @rdname FLoem-class
 setMethod("show", signature(object = "FLoem"),
@@ -141,8 +146,8 @@ setMethod("show", signature(object = "FLoem"),
  })
 
 #' @rdname FLoem-class
-setMethod("iter", signature(obj = "FLoem"),
-  function(obj, iter){
+setMethod("iters", signature(object = "FLoem"),
+  function(object, iter){
     # TODO Delve deeper into list
 	  deviances(object) <- lapply(deviances(object), FLCore::iter, iter)
 	  observations(object) <- lapply(observations(object), FLCore::iter, iter)


### PR DESCRIPTION
An attempt to get `iter` running for FLoem objects.

```
library(mse)
oem <- FLoem()
mse::iter(oem, 1)
# Error in h(simpleError(msg, call)) : 
#   error in evaluating the argument 'X' in selecting a method for 
# function 'lapply': error in evaluating the argument 'object' in 
# selecting a method for function 'deviances': object 'object' not found
```

This is required when `mp()` is parallelised. and the FLoem is split into its iterations:
<https://github.com/flr/mse/blob/94dc98db6b428e566a241b978150dec1319f6b7b/R/mp.R#L130>

Issues fixed:

1. Added missing replacement method for `deviances`, used inside `iters`
2. Fixed `iters` definition for class `FLiem` 

