### PR TITLE
keep results from last year(s) of goFish if management_lag>0

### DIFF
--- a/R/mp.R
+++ b/R/mp.R
@@ -246,21 +246,12 @@ mp <- function(om, oem=NULL, iem=NULL, control=ctrl, ctrl=control, args,
   if(!is(lst0$om, "FLo"))
     stop("goFish returned no results")
 
-  # GET objects back from loop, up to last projected year
-  om <- window(lst0$om, end=vy[length(vy)])
-
-  if(missingoem)
-    oem <- FLoem()
-  else
-    oem <- window(lst0$oem, end=vy[length(vy)])
-
-  tracking <- window(lst0$tracking, end=vy[length(vy)])
 
   if(verbose) cat("\n")
 
   # --- RETURN
-  res <- new("FLmse", om=om, args=args, oem=oem, control=ctrl,
-    tracking = tracking)
+  res <- new("FLmse", om=lst0$om, args=args, oem=lst0$oem, control=ctrl,
+    tracking = lst0$tracking)
   
   return(res)
 }
@@ -607,7 +598,7 @@ setMethod("goFish", signature(om="FLom"),
 
   # RETURN
   list(om=window(om, start=iy, end=fy), tracking=window(tracking, end=fy),
-    oem=oem, args=args)
+    oem=window(oem, end=fy), args=args)
   } 
 )
 # }}}
@@ -963,7 +954,7 @@ setMethod("goFish", signature(om="FLombf"),
 
   # RETURN
   list(om=window(om, start=iy, end=fy), tracking=window(tracking, end=fy),
-    oem=oem, args=args)
+       oem=window(oem, end=fy), args=args)
 
   }
 ) # }}}

--- a/R/mp.R
+++ b/R/mp.R
@@ -247,14 +247,14 @@ mp <- function(om, oem=NULL, iem=NULL, control=ctrl, ctrl=control, args,
     stop("goFish returned no results")
 
   # GET objects back from loop, up to last projected year
-  om <- window(lst0$om, end = ac(an(vy)[length(vy)] + management_lag))
+  om <- window(lst0$om, end=vy[length(vy)])
 
   if(missingoem)
     oem <- FLoem()
   else
-    oem <- window(lst0$oem, end = ac(an(vy)[length(vy)] + management_lag))
+    oem <- window(lst0$oem, end=vy[length(vy)])
 
-  tracking <- window(lst0$tracking, end = ac(an(vy)[length(vy)] + management_lag))
+  tracking <- window(lst0$tracking, end=vy[length(vy)])
 
   if(verbose) cat("\n")
 

--- a/R/mp.R
+++ b/R/mp.R
@@ -247,14 +247,14 @@ mp <- function(om, oem=NULL, iem=NULL, control=ctrl, ctrl=control, args,
     stop("goFish returned no results")
 
   # GET objects back from loop, up to last projected year
-  om <- window(lst0$om, end=vy[length(vy)])
+  om <- window(lst0$om, end = ac(an(vy)[length(vy)] + management_lag))
 
   if(missingoem)
     oem <- FLoem()
   else
-    oem <- window(lst0$oem, end=vy[length(vy)])
+    oem <- window(lst0$oem, end = ac(an(vy)[length(vy)] + management_lag))
 
-  tracking <- window(lst0$tracking, end=vy[length(vy)])
+  tracking <- window(lst0$tracking, end = ac(an(vy)[length(vy)] + management_lag))
 
   if(verbose) cat("\n")
 


### PR DESCRIPTION
In `goFish()`, the OM projection runs until the last year defined in `vy`
https://github.com/flr/mse/blob/aab32e1ab6b43355aa0b2890be40ea9fb22316e0/R/mp.R#L91

If `management_lag > 0`, `goFish()` also correctly fills some year(s) after the maximum of `vy`. However, later, these years are cut off again:
https://github.com/flr/mse/blob/aab32e1ab6b43355aa0b2890be40ea9fb22316e0/R/mp.R#L250

I suggest keeping these years, see the attached commit. 
Otherwise, the OM has be extended by `management_lag` years to keep the results before running `mp()`.
