### PR TITLE
fix seed for future

### DIFF
--- a/R/mp.R
+++ b/R/mp.R
@@ -211,7 +211,7 @@ mp <- function(om, oem=NULL, iem=NULL, control=ctrl, ctrl=control, args,
       .combine=.combinegoFish,
       .multicombine=TRUE, 
       .errorhandling = "remove", 
-      .options.future=list(globals=structure(TRUE, seed=seed)),
+      .options.future=list(seed=seed, globals=structure(TRUE)),
       .inorder=TRUE) %dofuture% {
       
         call0 <- list(
@@ -1022,8 +1022,8 @@ mps <- function(om, oem=NULL, iem=NULL, ctrl, args, names=NULL, parallel=TRUE,
     p <- progressor(along=seq(largs), offset=0L)
 
     res <- foreach(i = seq(largs), .errorhandling="pass",
-      .options.future=list(globals=structure(TRUE, add=c("ctrl", "module",
-      "mopts", "om", "oem", "iem", "args"), seed=seed))) %dofuture% {
+      .options.future=list(seed=seed, globals=structure(TRUE, add=c("ctrl", "module",
+      "mopts", "om", "oem", "iem", "args")))) %dofuture% {
 
       # MODIFY module args
       args(ctrl[[module]])[names(mopts)] <- lapply(mopts, "[", i)


### PR DESCRIPTION
It looks like there is a bug in how the seed argument is passed to future:
https://github.com/flr/mse/blob/4f50190052c64e2768e8cdea201d079d3dee80b6/R/mp.R#L214

If random numbers are generated when run in parallel, future returns a warning, even when `seed=TRUE` defined in `args`:

> `1: UNRELIABLE VALUE: Iteration 1 of the foreach() %dofuture% { ... }, part of chunk #1 (‘doFuture2-1’), unexpectedly generated random numbers without declaring so. There is a risk that those random numbers are not statistically sound and the overall results might be invalid. To fix this, specify foreach() argument '.options.future = list(seed = TRUE)'. This ensures that proper, parallel-safe random numbers are produced via the L'Ecuyer-CMRG method. To disable this check, set option 'doFuture.rng.onMisuse' to "ignore".`

I think the `seed` argument should be outside of `structure()`:
`.options.future=list(seed=seed, globals=structure(TRUE))`
instead of 
`.options.future=list(globals=structure(TRUE, seed=seed))`
which removes the warning message.