### PR TITLE
Fix bug in iter() for for mpCtrl

### DIFF
--- a/R/mpCtrl-class.R
+++ b/R/mpCtrl-class.R
@@ -289,7 +289,7 @@ setMethod("iters", signature(object = "mpCtrl"), function(object, i){
 
 #' @rdname mpCtrl-class
 setMethod("iter", signature(obj = "mpCtrl"), function(obj, i){
-  ctrl <- lapply(obj, iter, i=iter)
+  ctrl <- lapply(obj, iter, i=i)
   return(mpCtrl(ctrl))
 }) # }}}
 


### PR DESCRIPTION
There is a bug in the iter() method for class mpCtrl:

https://github.com/flr/mse/blob/71b3efc4932d02af580fe5b7399c149a44b6c17b/R/mpCtrl-class.R#L291-L294

If an argument of any of the `mseCtrl` modules of `mpCtrl` is an `FLQuant`, then `iter` will fail, e.g.
```
iter(mpCtrl(list(est = mseCtrl(
  method = perfect.sa,
  args = list(SSB_dev = FLQuant(dimnames = list(iter = 1:2)))))), 
  2)
```

This is because 
https://github.com/flr/mse/blob/71b3efc4932d02af580fe5b7399c149a44b6c17b/R/mpCtrl-class.R#L292
passes the function `iter` instead of the actual iterations `i`